### PR TITLE
Add `demoMaxDemand` Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The PowerTick Node.js API is built with Azure Functions and provides endpoints t
 | `/api/demoPowerFactorHistory`    | GET        | Retrieve power factor history for a powermeter.         |
 | `/api/demoRealtimeData`          | GET        | Retrieve the latest real-time data for a powermeter.    |
 | `/api/demoRegisterNewMeter`      | POST       | Register a new powermeter into the database.            |
+| `/api/demoMaxDemand`             | GET        | Retrieve max demand for a specific powermeter. 
 
 ### Public API Endpoints
 
@@ -63,6 +64,43 @@ The PowerTick Node.js API is built with Azure Functions and provides endpoints t
 ## Usage Examples
 
 Below are examples of how to interact with each API endpoint using `curl`.
+### `/api/demoMaxDemand` - GET
+
+**Description**: Retrieve max demand for a specific powermeter.
+
+**Examples**:
+
+- **Query for the past day**:
+  ```bash
+  curl -X GET "http://localhost:7071/api/demoMaxDemand?sn=DEMO0000003&time=day"
+  ```
+
+- **Query for the past month**:
+  ```bash
+  curl -X GET "http://localhost:7071/api/demoMaxDemand?sn=DEMO0000003&time=month"
+  ```
+
+- **Query for the past year**:
+  ```bash
+  curl -X GET "http://localhost:7071/api/demoMaxDemand?sn=DEMO0000003&time=year"
+  ```
+
+**Cloud Test Examples**:
+- **Query for the past day**:
+  ```bash
+  curl -X GET "https://powertick-api-js.azurewebsites.net/api/demoMaxDemand?sn=DEMO0000003&time=day"
+  ```
+
+- **Query for the past month**:
+  ```bash
+  curl -X GET "https://powertick-api-js.azurewebsites.net/api/demoMaxDemand?sn=DEMO0000003&time=month"
+  ```
+
+- **Query for the past year**:
+  ```bash
+  curl -X GET "https://powertick-api-js.azurewebsites.net/api/demoMaxDemand?sn=DEMO0000003&time=year"
+  ```
+
 
 ### `/api/demoConsumptionHistory` - GET
 

--- a/src/functions/demoMaxDemand.js
+++ b/src/functions/demoMaxDemand.js
@@ -1,0 +1,143 @@
+/**
+ * Author: Arturo Vargas Cuevas
+ * Last Modified Date: 2024-11-21
+ *
+ * This function serves as an HTTP GET endpoint to retrieve the maximum demand (total_real_power 
+ * and reactive_power_var) for a specific powermeter based on the provided serial number (`sn`) and 
+ * time range (`time`). The time range can be `year`, `month`, or `day`, and the function dynamically 
+ * determines the time zone for the powermeter based on its configuration in the `demo.powermeters` table.
+ *
+ * ### Objective:
+ * - Dynamically fetch the `time_zone` for the provided `sn` from the `demo.powermeters` table.
+ * - Retrieve the maximum values of `total_real_power` and `reactive_power_var` within the specified 
+ *   time range (year, month, or day) in the dynamically determined time zone.
+ * - Return both results as a JSON array.
+ *
+ * ### Conditions:
+ * - The `sn` (serial number) must exist in the `demo.powermeters` table.
+ * - The `time` parameter must be one of `year`, `month`, or `day`.
+ * - The queries are dynamically parameterized to support different time ranges and time zones.
+ *
+ * ### Example:
+ * curl -X GET "http://localhost:7071/api/demoMaxDemand?sn=DEMO0000001&time=day"
+ */
+
+const { app } = require('@azure/functions');
+const { getClient } = require('./dbClient');
+
+app.http('demoMaxDemand', {
+    methods: ['GET'],
+    authLevel: 'anonymous',
+    handler: async (request, context) => {
+        context.log(`Http function processed request for url "${request.url}"`);
+
+        const serialNumber = request.query.get('sn');
+        const time = request.query.get('time');
+
+        if (!serialNumber || !time) {
+            return {
+                status: 400,
+                body: {
+                    error: "Missing required query parameters 'sn' (serial number) and 'time'."
+                }
+            };
+        }
+
+        if (!['year', 'month', 'day'].includes(time)) {
+            return {
+                status: 400,
+                body: {
+                    error: "Invalid 'time' parameter. Valid values are 'year', 'month', 'day'."
+                }
+            };
+        }
+
+        const client = await getClient();
+
+        try {
+            // Get the time zone for the given serial number
+            const timeZoneQuery = `
+                SELECT time_zone
+                FROM demo.powermeters
+                WHERE serial_number = $1
+            `;
+            const timeZoneResult = await client.query(timeZoneQuery, [serialNumber]);
+
+            if (timeZoneResult.rows.length === 0) {
+                return {
+                    status: 404,
+                    body: {
+                        error: `No powermeter found with serial number '${serialNumber}'.`
+                    }
+                };
+            }
+
+            const timeZone = timeZoneResult.rows[0].time_zone;
+
+            // Define time range based on 'time' parameter
+            const dateTrunc = {
+                year: 'year',
+                month: 'month',
+                day: 'day'
+            }[time];
+
+            // Queries for total_real_power and reactive_power_var
+            const totalRealPowerQuery = `
+                SELECT 
+                  "timestamp",
+                  total_real_power
+                FROM demo.measurements
+                WHERE serial_number = $1
+                  AND "timestamp" AT TIME ZONE $2 >= date_trunc('${dateTrunc}', NOW() AT TIME ZONE $2)
+                  AND "timestamp" AT TIME ZONE $2 < date_trunc('${dateTrunc}', NOW() AT TIME ZONE $2) + INTERVAL '1 ${dateTrunc}'
+                  AND "timestamp" < NOW()
+                ORDER BY total_real_power DESC
+                LIMIT 1;
+            `;
+
+            const reactivePowerVarQuery = `
+                SELECT 
+                  "timestamp",
+                  reactive_power_var
+                FROM demo.measurements
+                WHERE serial_number = $1
+                  AND "timestamp" AT TIME ZONE $2 >= date_trunc('${dateTrunc}', NOW() AT TIME ZONE $2)
+                  AND "timestamp" AT TIME ZONE $2 < date_trunc('${dateTrunc}', NOW() AT TIME ZONE $2) + INTERVAL '1 ${dateTrunc}'
+                  AND "timestamp" < NOW()
+                ORDER BY total_real_power DESC
+                LIMIT 1;
+            `;
+
+            // Execute queries
+            const totalRealPowerResult = await client.query(totalRealPowerQuery, [serialNumber, timeZone]);
+            const reactivePowerVarResult = await client.query(reactivePowerVarQuery, [serialNumber, timeZone]);
+
+            // Prepare response JSON
+            const response = [
+                {
+                    type: "total_real_power",
+                    data: totalRealPowerResult.rows.length > 0 ? totalRealPowerResult.rows[0] : null
+                },
+                {
+                    type: "reactive_power_var",
+                    data: reactivePowerVarResult.rows.length > 0 ? reactivePowerVarResult.rows[0] : null
+                }
+            ];
+
+            // Return response
+            return {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(response)
+            };
+        } catch (error) {
+            context.log.error("Error executing queries:", error);
+            return {
+                status: 500,
+                body: { error: "An error occurred while processing your request." }
+            };
+        } finally {
+            client.release();
+        }
+    }
+});


### PR DESCRIPTION
## Overview
This pull request introduces the `demoMaxDemand` endpoint to the PowerTIC API, addressing the need to dynamically retrieve the maximum demand data (`total_real_power` and `reactive_power_var`) for a specific powermeter. The implementation dynamically determines the time zone of the powermeter based on its `serial_number` and supports user-defined time ranges (`year`, `month`, or `day`).

## Changes Made
- **New Endpoint**: `/api/demoMaxDemand`
  - **HTTP Method**: `GET`
  - **Query Parameters**:
    - `sn` (serial number): Required to identify the powermeter.
    - `time` (time range): Valid values are `year`, `month`, or `day`.
  - **Features**:
    - Dynamically fetches the time zone from the `demo.powermeters` table.
    - Executes SQL queries to retrieve maximum `total_real_power` and `reactive_power_var` for the specified time range.
    - Returns results as a JSON array containing both maximum values and their timestamps.

- **Validation**:
  - Ensures `sn` and `time` parameters are provided.
  - Validates that `time` is one of the accepted values: `year`, `month`, or `day`.
  - Returns `404` if the powermeter (`sn`) is not found.

- **Error Handling**:
  - Handles database connection errors and query execution issues.
  - Logs detailed error messages for debugging.

## Example Usage
### Request:
```bash
curl -X GET "http://localhost:7071/api/demoMaxDemand?sn=DEMO0000001&time=day"
