### PR TITLE
Add `demoPowermeterInfo` Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The PowerTick Node.js API is built with Azure Functions and provides endpoints t
 | `/api/demoRealtimeData`          | GET        | Retrieve the latest real-time data for a powermeter.    |
 | `/api/demoRegisterNewMeter`      | POST       | Register a new powermeter into the database.            |
 | `/api/demoMaxDemand`             | GET        | Retrieve max demand for a specific powermeter. 
+| `/api/demoPowermeterInfo`        | GET        | Retrieve specific information for a powermeter.         |
 
 ### Public API Endpoints
 
@@ -32,6 +33,7 @@ The PowerTick Node.js API is built with Azure Functions and provides endpoints t
 | `/api/getPowerMetersInfo` | GET        | Retrieve all powermeters in the database.               |
 | `/api/postReading`        | POST       | Submit a new reading for a powermeter.                  |
 | `/api/registerNewMeter`   | POST       | Register a new powermeter into the database.            |
+| `/api/powerMeterInfo`     | GET        | Retrieve specific information for a powermeter.         |
 
 ### Test API Endpoints
 
@@ -64,6 +66,40 @@ The PowerTick Node.js API is built with Azure Functions and provides endpoints t
 ## Usage Examples
 
 Below are examples of how to interact with each API endpoint using `curl`.
+### `/api/demoPowermeterInfo` - GET
+
+**Description**: Retrieve specific information for a powermeter.
+
+**Examples**:
+
+- **Local Test**:
+  ```bash
+  curl -X GET "http://localhost:7071/api/demoPowermeterInfo?sn=DEMO0000003"
+  ```
+
+- **Cloud Test**:
+  ```bash
+  curl -X GET "https://powertick-api-js.azurewebsites.net/api/demoPowermeterInfo?sn=DEMO0000003"
+  ```
+
+---
+
+### `/api/powerMeterInfo` - GET
+
+**Description**: Retrieve specific information for a powermeter in the dev environment.
+
+**Examples**:
+
+- **Local Test**:
+  ```bash
+  curl -X GET "http://localhost:7071/api/powerMeterInfo?sn=DEMO0000003"
+  ```
+
+- **Cloud Test**:
+  ```bash
+  curl -X GET "https://powertick-api-js.azurewebsites.net/api/powerMeterInfo?sn=DEMO0000003"
+  ```
+  
 ### `/api/demoMaxDemand` - GET
 
 **Description**: Retrieve max demand for a specific powermeter.

--- a/src/functions/demoPowerMeterInfo.js
+++ b/src/functions/demoPowerMeterInfo.js
@@ -1,0 +1,56 @@
+const { app } = require('@azure/functions');
+const { getClient } = require('./dbClient');
+
+app.http('demoPowerMeterInfo', {
+    methods: ['GET'],
+    authLevel: 'anonymous',
+    handler: async (request, context) => {
+        context.log(`Http function processed request for url "${request.url}"`);
+
+        // Parse query parameter
+        const serialNumber = request.query.get('sn');
+
+        if (!serialNumber) {
+            return {
+                status: 400,
+                body: JSON.stringify({ error: "Missing required query parameter 'sn' (serial number)." })
+            };
+        }
+
+        const client = await getClient();
+
+        try {
+            // Query to get powermeter information
+            const query = `
+                SELECT * 
+                FROM demo.powermeters
+                WHERE serial_number = $1
+                ORDER BY serial_number ASC;
+            `;
+            const result = await client.query(query, [serialNumber]);
+
+            // Check if the result is empty
+            if (result.rows.length === 0) {
+                return {
+                    status: 404,
+                    body: JSON.stringify({ error: `No powermeter found with serial number '${serialNumber}'` })
+                };
+            }
+
+            // Return the data as JSON
+            return {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(result.rows) // Serialize the response to JSON
+            };
+        } catch (error) {
+            context.log.error("Error executing query:", error);
+            return {
+                status: 500,
+                body: JSON.stringify({ error: "An error occurred while processing your request." })
+            };
+        } finally {
+            client.release();
+        }
+    }
+});

--- a/src/functions/powerMeterInfo.js
+++ b/src/functions/powerMeterInfo.js
@@ -1,0 +1,56 @@
+const { app } = require('@azure/functions');
+const { getClient } = require('./dbClient');
+
+app.http('powerMeterInfo', {
+    methods: ['GET'],
+    authLevel: 'anonymous',
+    handler: async (request, context) => {
+        context.log(`Http function processed request for url "${request.url}"`);
+
+        // Parse query parameter
+        const serialNumber = request.query.get('sn');
+
+        if (!serialNumber) {
+            return {
+                status: 400,
+                body: JSON.stringify({ error: "Missing required query parameter 'sn' (serial number)." })
+            };
+        }
+
+        const client = await getClient();
+
+        try {
+            // Query to get powermeter information
+            const query = `
+                SELECT * 
+                FROM dev.powermeters
+                WHERE serial_number = $1
+                ORDER BY serial_number ASC;
+            `;
+            const result = await client.query(query, [serialNumber]);
+
+            // Check if the result is empty
+            if (result.rows.length === 0) {
+                return {
+                    status: 404,
+                    body: JSON.stringify({ error: `No powermeter found with serial number '${serialNumber}'` })
+                };
+            }
+
+            // Return the data as JSON
+            return {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(result.rows) // Serialize the response to JSON
+            };
+        } catch (error) {
+            context.log.error("Error executing query:", error);
+            return {
+                status: 500,
+                body: JSON.stringify({ error: "An error occurred while processing your request." })
+            };
+        } finally {
+            client.release();
+        }
+    }
+});


### PR DESCRIPTION
## Overview
This pull request introduces the `demoPowermeterInfo` endpoint to the PowerTIC API. This endpoint allows users to retrieve detailed information about a specific powermeter by providing its serial number (`sn`). The implementation retrieves all columns from the `demo.powermeters` table and returns the result as a JSON object.

## Changes Made
- **New Endpoint**: `/api/demoPowermeterInfo`
  - **HTTP Method**: `GET`
  - **Query Parameters**:
    - `sn` (serial number): Required to identify the powermeter.
  - **Features**:
    - Executes a SQL query to retrieve all columns from the `demo.powermeters` table for the specified serial number.
    - Returns the result as a JSON object.

- **Validation**:
  - Ensures the `sn` parameter is provided.
  - Returns a `400 Bad Request` error if the parameter is missing.
  - Returns a `404 Not Found` error if the powermeter does not exist.

- **Error Handling**:
  - Handles database connection errors and query execution issues.
  - Logs detailed error messages for debugging.

## Example Usage
### Request:
```bash
curl -X GET "http://localhost:7071/api/demoPowermeterInfo?sn=DEMO0000003"
